### PR TITLE
Adds support for hardware-accelerated video encoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -174,7 +174,8 @@ ffmpegUfvPlatform.prototype.accessories = function(callback) {
                         "maxStreams": 2,
                         "maxWidth": discoveredChannel.width, // or however we end up getting to this!
                         "maxHeight": discoveredChannel.height,
-                        "maxFPS": discoveredChannel.fps
+                        "maxFPS": discoveredChannel.fps,
+                        "vaapiDevice": nvrConfig.vaapiDevice
                       };
 
                       debug('Config: ' + JSON.stringify(videoConfig));
@@ -191,7 +192,7 @@ ffmpegUfvPlatform.prototype.accessories = function(callback) {
 
                       debug(JSON.stringify(cameraConfig));
 
-                      var cameraSource = new UFV(hap, cameraConfig);
+                      var cameraSource = new UFV(self.log, hap, cameraConfig);
                       cameraAccessory.configureCameraSource(cameraSource);
                       configuredAccessories.push(cameraAccessory);
 

--- a/ufv.js
+++ b/ufv.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var debug = require('debug')('ffmpeg');
-
 var http = require('http');
 var https = require('https');
 var url = require('url');
@@ -9,7 +7,6 @@ var crypto = require('crypto');
 
 var uuid, Service, Characteristic, StreamController;
 
-var fs = require('fs');
 var ip = require('ip');
 var spawn = require('child_process').spawn;
 
@@ -17,7 +14,8 @@ module.exports = {
   UFV: UFV
 };
 
-function UFV(hap, cameraConfig) {
+function UFV(log, hap, cameraConfig) {
+  this.log = log;
   uuid = hap.uuid;
   Service = hap.Service;
   Characteristic = hap.Characteristic;
@@ -26,6 +24,7 @@ function UFV(hap, cameraConfig) {
   var ffmpegOpt = cameraConfig.videoConfig;
   this.name = cameraConfig.name;
   this.vcodec = ffmpegOpt.vcodec;
+  this.vaapiDevice = ffmpegOpt.vaapiDevice;
 
   if (!ffmpegOpt.source) {
     throw new Error("Missing source for camera.");
@@ -99,6 +98,9 @@ function UFV(hap, cameraConfig) {
     }
   }
 
+  this.log.debug('Camera ' + this.name + ': maximum resolution ' + this.maxWidth + 'x' + this.maxHeight + '@' + maxFPS + ', '
+      + 'supported resolutions: ' + videoResolutions.map(r => r[0] + 'x' + r[1] + '@' + r[2]).join(', '));
+
   let options = {
     proxy: false, // Requires RTP/RTCP MUX Proxy
     srtp: true, // Supports SRTP AES_CM_128_HMAC_SHA1_80 encryption
@@ -110,6 +112,7 @@ function UFV(hap, cameraConfig) {
       }
     },
     audio: {
+      comfort_noise: true,
       codecs: [
         {
           type: "OPUS", // Audio Codec
@@ -142,7 +145,7 @@ UFV.prototype.handleSnapshotRequest = function(request, callback) {
     var imageSource = this.ffmpegSource;
     let ffmpeg = spawn('ffmpeg', (imageSource + ' -t 1 -s '+ resolution + ' -f image2 -').split(' '), {env: process.env});
     var imageBuffer = Buffer(0);
-    console.log("Snapshot",imageSource + ' -t 1 -s '+ resolution + ' -f image2 -');
+    this.log.debug("Snapshot", imageSource + ' -t 1 -s ' + resolution + ' -f image2 -');
     ffmpeg.stdout.on('data', function(data) {
       imageBuffer = Buffer.concat([imageBuffer, data]);
     });
@@ -163,7 +166,6 @@ UFV.prototype.handleSnapshotRequest = function(request, callback) {
         data.push(chunk);
       }).on('end', function() {
         var buffer = Buffer.concat(data);
-        debug('returning image');
         callback(undefined, buffer);
       });
     });
@@ -185,7 +187,7 @@ UFV.prototype.prepareStream = function(request, callback) {
     let targetPort = videoInfo["port"];
     let srtp_key = videoInfo["srtp_key"];
     let srtp_salt = videoInfo["srtp_salt"];
-    
+
     // SSRC is a 32 bit integer that is unique per stream
 
     let ssrcSource = crypto.randomBytes(4);
@@ -211,7 +213,7 @@ UFV.prototype.prepareStream = function(request, callback) {
     let targetPort = audioInfo["port"];
     let srtp_key = audioInfo["srtp_key"];
     let srtp_salt = audioInfo["srtp_salt"];
-    
+
     // SSRC is a 32 bit integer that is unique per stream
     let ssrcSource = crypto.randomBytes(4);
     ssrcSource[0] = 0;
@@ -257,14 +259,21 @@ UFV.prototype.handleStreamRequest = function(request) {
     if (requestType == "start") {
       var sessionInfo = this.pendingSessions[sessionIdentifier];
       if (sessionInfo) {
+        // set sane defaults for the output video stream
         var width = 1280;
         var height = 720;
         var fps = 30;
-        var bitrate = 300;
-        var vcodec = this.vcodec || 'libx264';
+        var videoBitrate = 300;
+        var videoPt = 99;
+
+        var audioBitrate = 24;
+        var audioPt = 110;
+
+        var mtu = 1378;
 
         let videoInfo = request["video"];
         if (videoInfo) {
+          // Override video stream settings if present in the client request
           width = videoInfo["width"];
           height = videoInfo["height"];
 
@@ -273,21 +282,89 @@ UFV.prototype.handleStreamRequest = function(request) {
             fps = expectedFPS;
           }
 
-          bitrate = videoInfo["max_bit_rate"];
+          videoBitrate = videoInfo["max_bit_rate"];
+          videoPt = videoInfo["pt"];
+
+          mtu = videoInfo["mtu"];
+
+          // We may want to pick up "profile" and "level",
+          // but I'm not sure how to convert them to values
+          // ffmpeg understands.
+        }
+
+        let audioInfo = request["audio"];
+        if (audioInfo) {
+          // Override audio stream settings if present in the client request
+          audioBitrate = audioInfo["max_bit_rate"];
+          audioPt = audioInfo["pt"];
         }
 
         let targetAddress = sessionInfo["address"];
         let targetVideoPort = sessionInfo["video_port"];
         let videoKey = sessionInfo["video_srtp"];
         let videoSsrc = sessionInfo["video_ssrc"];
+        let targetAudioPort = sessionInfo["audio_port"];
+        let audioKey = sessionInfo["audio_srtp"];
+        let audioSsrc = sessionInfo["audio_ssrc"];
 
-        let ffmpegCommand = this.ffmpegSource + ' -threads 0 -vcodec '+vcodec+' -an -pix_fmt yuv420p -r '+
-        fps +' -f rawvideo -tune zerolatency -vf scale='+ width +':'+ height +' -b:v '+ bitrate +'k -bufsize '+
-         bitrate +'k -payload_type 99 -ssrc '+ videoSsrc +' -f rtp -srtp_out_suite AES_CM_128_HMAC_SHA1_80 -srtp_out_params '+
-         videoKey.toString('base64')+' srtp://'+targetAddress+':'+targetVideoPort+'?rtcpport='+targetVideoPort+
-         '&localrtcpport='+targetVideoPort+'&pkt_size=1378';
-        console.log(ffmpegCommand);
-        let ffmpeg = spawn('ffmpeg', ffmpegCommand.split(' '), {env: process.env});
+        this.log.debug('Client request configuration: ' + JSON.stringify(request) + '. '
+            + 'Transcode configuration: ' + JSON.stringify(sessionInfo));
+
+        let ffmpegCommand;
+        if (!this.vaapiDevice) {
+          // "Normal" run without hardware acceleration
+          ffmpegCommand = ''
+              + this.ffmpegSource + ' '
+              // Use software h264 encoder, scale picture to the desired size
+              + '-c:v libx264 -vf scale=' + width + ':' + height + ' '
+              // Use as many threads as necessary, try to reduce latency if possible
+              + '-threads 0 -tune zerolatency ';
+        } else {
+          if (!this.vaapiDevice.startsWith('/dev/')) {
+            // Sanity check that the filename is a device
+            this.log.error("Unexpected VAAPI device: " + this.vaapiDevice + " Expected example: /dev/dri/renderD128");
+          }
+          // Use VAAPI-based hardware acceleration
+          ffmpegCommand = ''
+              // Enable hardware decoding
+              + '-hwaccel vaapi -hwaccel_output_format vaapi '
+              // Enable hardware scaling and encoding
+              + '-vaapi_device ' + this.vaapiDevice + ' '
+              + this.ffmpegSource + ' '
+              // Use hardware encoder, after decoder upload frame to the hardware encoder and scale it there
+              + '-c:v h264_vaapi -vf format=nv12|vaapi,hwupload,scale_vaapi=w=' + width + ':h=' + height + ' '
+              // Profiles are required to make iOS/maCOS happy
+              + '-profile:v 578 -bf 0 -tune zerolatency '
+        }
+        ffmpegCommand = ffmpegCommand
+            // Encode video only in this stream #0, do it fast and limit fps and bitrate
+            + '-an -f rawvideo -r ' + fps + ' -b:v ' + videoBitrate + 'k -bufsize ' + videoBitrate + 'k '
+            // Define protocol-level configs for video
+            + '-payload_type ' + videoPt + ' -ssrc ' + videoSsrc + ' '
+            // Wrap video into an encrypted RTP stream
+            + '-f rtp -srtp_out_suite AES_CM_128_HMAC_SHA1_80 -srtp_out_params ' + videoKey.toString('base64') + ' '
+            // Specify all the ports/addresses for the stream
+            + 'srtp://' + targetAddress + ':' + targetVideoPort
+            + '?rtcpport=' + targetVideoPort + '&localrtcpport=' + targetVideoPort + '&pkt_size=' + mtu + ' '
+            // Encode audio only in this stream #1, use iOS-specific AAC with limited bitrate
+            + '-vn -acodec aac -profile:a aac_eld -b:a ' + audioBitrate + 'k -bufsize ' + audioBitrate + 'k '
+            // Define protocol-level configs for audio
+            + '-payload_type ' + audioPt + ' -ssrc ' + audioSsrc + ' '
+            // Wrap audio into an encrypted RTP stream
+            + '-f rtp -srtp_out_suite AES_CM_128_HMAC_SHA1_80 -srtp_out_params ' + audioKey.toString('base64') + ' '
+            // Specify all the ports/addresses for the stream
+            + 'srtp://' + targetAddress + ':' + targetAudioPort
+            + '?rtcpport=' + targetAudioPort + '&localrtcpport=' + targetAudioPort + '&pkt_size=' + mtu;
+
+        this.log.info('Starting video transcode: ffmpeg ' + ffmpegCommand.replace(/([|?&><])/g, '\\$1'));
+        // Less verbose logs on a server
+        let ffmpeg = spawn('ffmpeg', ('-loglevel warning ' + ffmpegCommand).split(' '));
+        ffmpeg.stdout.on('data', (data) => {
+          this.log.debug("  " + data);
+        });
+        ffmpeg.stderr.on('data', (data) => {
+          this.log.debug("  " + data);
+        });
         this.ongoingSessions[sessionIdentifier] = ffmpeg;
       }
 


### PR DESCRIPTION
To enable hardware-accelerated video encoding add a new config option:
`"vaapiDevice": "/dev/dri/renderD128"` (Intel CPU example).
This would pass a new set of options to ffmpeg:
`-hwaccel vaapi -hwaccel_output_format vaapi -vaapi_device /dev/dri/renderD128`
and it would replace
`-c:v libx264 -vf scale=1280:720 -threads 0 -tune zerolatency`
with
`-c:v h264_vaapi -vf format=nv12|vaapi,hwupload,scale_vaapi=w=720:h=480 -threads 1`

Verified to work on Synology NAS DS718+ within Docker environment.
More details https://timothybasanov.com/2018/12/08/hardware-accelerated-h264-encoding-synology-nas.html
Gotchas: One needs to correctly pass devs into docker and give
access to a Homebridge's user.

Additional changes:
 - Support for audio encoding
 - Better logging integration with Homebridge
 - Logs from ffmpeg in Homebridge's logs