### PR TITLE
Account for empty channel array

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,7 +133,7 @@ ffmpegUfvPlatform.prototype.accessories = function(callback) {
                   // Each camera has more than one channel.
                   // The channel is where the actual streaming params live:
 
-                  var discoveredChannels = discoveredCamera.channels;
+                  var discoveredChannels = ( discoveredCamera.channels || [] );
 
                   // Go through each channel, see if it is rtspEnabled, and if so,
                   // post it to homebridge and move on to the next camera


### PR DESCRIPTION
I have a case where I had a camera that is known to the NVR, but not managed. In this case, the channel array is null, and causes an error on discoveredChannels.length. Defaulting to an empty array solves this problem.