### PR TITLE
Add support for one-way audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ On your homebridge system, edit config.json to add a platform block like this:
       "apiPort": 7443,
       "apiProtocol": "https",
       "apiKey": "<api key from NVR user settings>",
-      "motionSensors": true
+      "motionSensors": true,
+      "audio": true
     }
   ]
 }

--- a/index.js
+++ b/index.js
@@ -174,7 +174,8 @@ ffmpegUfvPlatform.prototype.accessories = function(callback) {
                         "maxStreams": 2,
                         "maxWidth": discoveredChannel.width, // or however we end up getting to this!
                         "maxHeight": discoveredChannel.height,
-                        "maxFPS": discoveredChannel.fps
+                        "maxFPS": discoveredChannel.fps,
+                        "audio": nvrConfig.audio === true
                       };
 
                       debug('Config: ' + JSON.stringify(videoConfig));


### PR DESCRIPTION
Adds support for turning on audio _from_ the camera to HomeKit.

Off by default, but turned on via an `audio: true` config param.  Requires ffmpeg to be compiled with fdk-aac.

Fixes #33 